### PR TITLE
[MAINT] Reimplemented Core.Timer unit test using C++11 libraries (`std::thread` and `std::chrono`).

### DIFF
--- a/test/Core/CMakeLists.txt
+++ b/test/Core/CMakeLists.txt
@@ -21,5 +21,5 @@ do_unit_test(Core_MultiArray test_MultiArray.cpp "${DO_LIBRARIES}"
              ${TestGroupName})# ${TestPch})
 do_unit_test(Core_Tree test_Tree.cpp "${DO_LIBRARIES}" 
              ${TestGroupName})# ${TestPch})
-do_unit_test(Core_Timer test_Timer.cpp "${DO_LIBRARIES};TinyThread"
+do_unit_test(Core_Timer test_Timer.cpp "${DO_LIBRARIES}"
              ${TestGroupName})# ${TestPch})

--- a/test/Core/test_Timer.cpp
+++ b/test/Core/test_Timer.cpp
@@ -12,25 +12,16 @@
 #include <gtest/gtest.h>
 #include <DO/Core/Timer.hpp>
 #include <DO/Core/DebugUtilities.hpp>
-#include <TinyThread++/source/tinythread.h>
+#include <chrono>
+#include <thread>
 
 using namespace DO;
 using namespace std;
 
 inline void wait(unsigned milliseconds)
 {
-#ifdef _WIN32
-  Sleep(milliseconds);
-#else
-  usleep(milliseconds*1e3);
-#endif
-}
-
-// Thread function: Detach
-void oneSecondSleep(void *)
-{
-  // We don't do anything much, just sleep a little...
-  tthread::this_thread::sleep_for(tthread::chrono::milliseconds(1000));
+  chrono::milliseconds duration(milliseconds);
+  this_thread::sleep_for(duration);
 }
 
 TEST(DO_Core_Test,  testTimer)
@@ -39,7 +30,7 @@ TEST(DO_Core_Test,  testTimer)
   HighResTimer hrTimer;
   double elapsedTimeMs;
   double elapsedTimeS;
-  double sleepTimeMs = 1e3;
+  unsigned sleepTimeMs = 1000;
 
   hrTimer.restart();
   wait(sleepTimeMs);
@@ -53,9 +44,7 @@ TEST(DO_Core_Test,  testTimer)
   
   timer.restart();
   // Start the child thread
-  tthread::thread t(oneSecondSleep, 0);
-  // Wait for the thread to finish
-  t.join();
+  wait(sleepTimeMs);
   elapsedTimeS = timer.elapsed();
   EXPECT_NEAR(elapsedTimeS, sleepTimeMs/1e3, 1e-3);
 }


### PR DESCRIPTION
Because I forgot to fix compilation test after removing dependencies with TinyThread++.
