### PR TITLE
[FIX] Made `DO::Timer` implementation C++98 compliant.

### DIFF
--- a/src/DO/Core/Timer.cpp
+++ b/src/DO/Core/Timer.cpp
@@ -21,21 +21,6 @@
 namespace DO {
 
   Timer::Timer()
-  {
-  }
-  
-  void Timer::restart()
-  {
-    start_ = std::chrono::high_resolution_clock::now();
-  }
-
-  double Timer::elapsed()
-  {
-    end_ = std::chrono::high_resolution_clock::now();
-    return std::chrono::duration<double>(end_-start_).count();
-  }
-
-  HighResTimer::HighResTimer()
     : elapsed_(0)
   {
 #ifdef WIN32
@@ -49,8 +34,8 @@ namespace DO {
     frequency_ = static_cast<double>(freq.QuadPart);
 #endif
   }
-  //! Reset the timer to zero.
-  void HighResTimer::restart()
+
+  void Timer::restart()
   {
 #ifdef WIN32
     LARGE_INTEGER li_start_;
@@ -62,8 +47,8 @@ namespace DO {
     start_ = start.tv_sec + start.tv_usec * 1e-6;
 #endif
   }
-  //! Returns the elapsed time in seconds.
-  double HighResTimer::elapsed()
+
+  double Timer::elapsed()
   {
 #ifdef _WIN32
     LARGE_INTEGER end_;
@@ -78,7 +63,7 @@ namespace DO {
     return elapsed_;
   }
 
-  double HighResTimer::elapsedMs()
+  double Timer::elapsedMs()
   {
     return elapsed() * 1000.; 
   }

--- a/src/DO/Core/Timer.hpp
+++ b/src/DO/Core/Timer.hpp
@@ -15,7 +15,6 @@
 #define DO_UTILITIES_TIMER_HPP
 
 #include <DO/Defines.hpp>
-#include <chrono>
 #include <iostream>
 
 namespace DO {
@@ -24,29 +23,12 @@ namespace DO {
   //! \defgroup Utility Utility
   //! @{
 
-  //! \brief Timer class.
+  //! \brief Timer class with microsecond accuracy.
   class DO_EXPORT Timer
   {
   public: /* interface. */
     //! Default constructor
     Timer();
-    //! Reset the timer to zero.
-    void restart();
-    //! Returns the elapsed time.
-    double elapsed();
-  private:
-    //! Records the start instant time.
-    std::chrono::time_point<std::chrono::high_resolution_clock> start_;
-    //! Records the end instant time.
-    std::chrono::time_point<std::chrono::high_resolution_clock> end_;
-  };
-
-  //! \brief Timer class with microsecond accuracy.
-  class DO_EXPORT HighResTimer
-  {
-  public: /* interface. */
-    //! Default constructor
-    HighResTimer();
     //! Reset the timer to zero.
     void restart();
     //! Returns the elapsed time in seconds.

--- a/test/Core/test_Timer.cpp
+++ b/test/Core/test_Timer.cpp
@@ -27,25 +27,19 @@ inline void milliSleep(unsigned milliseconds)
 TEST(DO_Core_Test, testTimer)
 {
   Timer timer;
-  HighResTimer hrTimer;
   double elapsedTimeMs;
   double elapsedTimeS;
   unsigned sleepTimeMs = 580;
 
-  hrTimer.restart();
+  timer.restart();
   milliSleep(sleepTimeMs);
-  elapsedTimeMs =  hrTimer.elapsedMs();
+  elapsedTimeMs =  timer.elapsedMs();
   EXPECT_NEAR(elapsedTimeMs, sleepTimeMs, 100);
-
-  hrTimer.restart();
-  milliSleep(sleepTimeMs);
-  elapsedTimeS = hrTimer.elapsed();
-  EXPECT_NEAR(elapsedTimeS, sleepTimeMs/1e3, 2e-3);
 
   timer.restart();
   milliSleep(sleepTimeMs);
   elapsedTimeS = timer.elapsed();
-  EXPECT_NEAR(elapsedTimeS, sleepTimeMs/1e3, 1e-2);
+  EXPECT_NEAR(elapsedTimeS, sleepTimeMs/1e3, 2e-3);
 }
 
 int main(int argc, char** argv) 


### PR DESCRIPTION
This PR addresses issue #23.
