### PR TITLE
[MAINT] Remove unneeded include file in unit test.

### DIFF
--- a/test/Graphics/test_painting_window.cpp
+++ b/test/Graphics/test_painting_window.cpp
@@ -661,4 +661,3 @@ int main(int argc, char *argv[])
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }
-#include "test_painting_window.moc"


### PR DESCRIPTION
As the title says.
