### PR TITLE
[MAINT] Silence `Core_Defines` test.

### DIFF
--- a/test/Core/test_Defines.cpp
+++ b/test/Core/test_Defines.cpp
@@ -16,10 +16,7 @@ using namespace std;
 
 TEST(DO_Core_Test, definesTest)
 {
-  cout << "DO++ version: " << DO_VERSION << endl;
   EXPECT_EQ(string(DO_VERSION), "1.0.0");
-
-  cout << "string source path: " << endl << srcPath("") << endl << endl;
   EXPECT_TRUE( string(srcPath("")).find("test/Core") != string::npos );
 }
 


### PR DESCRIPTION
As the title says.
