### PR TITLE
[MAINT] Resolve a few compiler warnings in unit tests for the `Core` module.

### DIFF
--- a/test/Core/test_Tree.cpp
+++ b/test/Core/test_Tree.cpp
@@ -49,9 +49,7 @@ TEST(DO_Core_Test, treeTest)
 {
   typedef Tree<int>::node_handle node_handle;
   typedef Tree<int>::depth_first_iterator depth_first_iterator;
-  typedef Tree<int>::breadth_first_iterator breadth_first_iterator;
   typedef Tree<int>::breadth_first_iterator breadth_first_queued_iterator;
-  typedef Tree<int>::children_iterator children_iterator;
   typedef Tree<int>::leaf_iterator leaf_iterator;
 
   // Create the tree.

--- a/test/Core/test_multiarray.cpp
+++ b/test/Core/test_multiarray.cpp
@@ -43,7 +43,6 @@ TYPED_TEST_P(Test_multiarray_constructors,
 {
   typedef TypeParam MultiArray;
   typedef typename MultiArray::vector_type Vector;
-  typedef typename MultiArray::size_type size_type;
   typedef StrideComputer<MultiArray::StorageOrder> StrideComputer;
 
   // Create sizes, one for each dimension.


### PR DESCRIPTION
As the title says.
