### PR TITLE
MAINT: fix installation of Debian packages.

### DIFF
--- a/third-party/antigrain/CMakeLists.txt
+++ b/third-party/antigrain/CMakeLists.txt
@@ -6,6 +6,9 @@ include_directories (include)
 file (GLOB antigrain_HEADERS include/*.h)
 file (GLOB antigrain_SOURCES src/*.cpp)
 add_library (antigrain ${antigrain_SOURCES} ${antigrain_HEADERS})
+set_target_properties(antigrain
+  PROPERTIES
+  OUTPUT_NAME_DEBUG antigrain-d)
 install(TARGETS antigrain
         LIBRARY DESTINATION lib
         ARCHIVE DESTINATION lib

--- a/third-party/flann/src/cpp/CMakeLists.txt
+++ b/third-party/flann/src/cpp/CMakeLists.txt
@@ -17,6 +17,9 @@ file(GLOB_RECURSE CU_SOURCES *.cu)
 # Create the static C++ library.
 # 
 add_library(flann_cpp_s STATIC ${CPP_SOURCES})
+set_target_properties(flann_cpp_s
+  PROPERTIES
+  OUTPUT_NAME_DEBUG flann_cpp_s-d)
 if(CMAKE_COMPILER_IS_GNUCC)
     set_target_properties(flann_cpp_s PROPERTIES COMPILE_FLAGS -fPIC)
 endif()


### PR DESCRIPTION
Debug and release packages conflict because debug and release binaries are identical in some third-party libraries.