### PR TITLE
MAINT: explicitly generate default constructor in a C++11 way.

### DIFF
--- a/src/DO/Sara/Core/Image/Image.hpp
+++ b/src/DO/Sara/Core/Image/Image.hpp
@@ -68,15 +68,11 @@ namespace DO { namespace Sara {
 
   public:
     //! Default image constructor.
-    inline ImageBase()
-      : base_type{}
-    {
-    }
+    inline ImageBase() = default;
 
     //! Image constructor.
     inline ImageBase(pointer data, const vector_type& sizes)
-      : base_type{ data, sizes }
-    {
+      : base_type{ data, sizes } {
     }
 
     //! @{
@@ -180,18 +176,15 @@ namespace DO { namespace Sara {
 
   //! \brief The image class.
   template <typename T, int N>
-  class Image : public ImageBase < MultiArray<T, N, ColMajor> >
+  class Image : public ImageBase<MultiArray<T, N, ColMajor>>
   {
-    using base_type = ImageBase < MultiArray<T, N, ColMajor> > ;
+    using base_type = ImageBase<MultiArray<T, N, ColMajor>>;
 
   public: /* interface */
     using vector_type = typename base_type::vector_type;
 
     //! Default constructor.
-    inline Image()
-      : base_type{}
-    {
-    }
+    inline Image() = default;
 
     //! Constructor that takes ownership of data.
     inline explicit Image(T *data, const vector_type& sizes)

--- a/src/DO/Sara/Core/MultiArray/MultiArray.hpp
+++ b/src/DO/Sara/Core/MultiArray/MultiArray.hpp
@@ -45,10 +45,7 @@ namespace DO { namespace Sara {
 
   public: /* interface */
     //! \brief Default constructor that constructs an empty ND-array.
-    inline MultiArray()
-      : base_type{}
-    {
-    }
+    inline MultiArray() = default;
 
     //! \brief Constructor that takes **ownership** of the data.
     //! The data will be cleared upon destruction of the MultiArray object.

--- a/src/DO/Sara/Core/MultiArray/MultiArrayView.hpp
+++ b/src/DO/Sara/Core/MultiArray/MultiArrayView.hpp
@@ -352,9 +352,9 @@ namespace DO { namespace Sara {
     //! \brief Last element of the internal array.
     value_type *_end{ nullptr };
     //! \brief Sizes vector.
-    vector_type _sizes{ vector_type::Zero() };
+    vector_type _sizes = vector_type::Zero();
     //! \brief Strides vector.
-    vector_type _strides{ vector_type::Zero() };
+    vector_type _strides = vector_type::Zero();
   };
 
 } /* namespace Sara */

--- a/src/DO/Sara/Core/MultiArray/MultiArrayView.hpp
+++ b/src/DO/Sara/Core/MultiArray/MultiArrayView.hpp
@@ -97,7 +97,9 @@ namespace DO { namespace Sara {
 
   public: /* methods */
     //! \brief Default constructor.
-    inline MultiArrayView() = default;
+    inline MultiArrayView()
+    {
+    }
 
     //! \brief Constructor that wraps plain data with its known sizes.
     inline MultiArrayView(value_type *data,
@@ -352,9 +354,9 @@ namespace DO { namespace Sara {
     //! \brief Last element of the internal array.
     value_type *_end{ nullptr };
     //! \brief Sizes vector.
-    vector_type _sizes = vector_type::Zero();
+    vector_type _sizes{ vector_type::Zero() };
     //! \brief Strides vector.
-    vector_type _strides = vector_type::Zero();
+    vector_type _strides{ vector_type::Zero() };
   };
 
 } /* namespace Sara */


### PR DESCRIPTION
As the title says.