### PR TITLE
MAINT: make a stricter fix for backward compatibility with older FFmp…

### DIFF
--- a/src/DO/Sara/VideoIO/VideoStream.cpp
+++ b/src/DO/Sara/VideoIO/VideoStream.cpp
@@ -140,11 +140,10 @@ namespace DO { namespace Sara {
     if (_video_codec_context)
     {
       avcodec_close(_video_codec_context);
-#if (LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(55, 28, 1))
-      avcodec_free_context(&_video_codec_context);
-#else
+      // For backward compatibility with older FFmpeg versions, don't use
+      //avcodec_free_context(&_video_codec_context);
+      // Instead call the following:
       av_freep(&_video_codec_context);
-#endif
       _video_codec_context = nullptr;
       _video_codec = nullptr;
     }


### PR DESCRIPTION
I have run into this problem on a build machine... So the best thing to do is not to use `avcodec_free_context` and instead use `av_freep`.