### PR TITLE
HOTFIX: don't build video I/O for python.

### DIFF
--- a/python/do/sara/pysara.cpp
+++ b/python/do/sara/pysara.cpp
@@ -13,5 +13,5 @@ BOOST_PYTHON_MODULE(pysara)
   expose_disjoint_sets();
   expose_geometry();
   expose_image_io();
-  expose_video_io();
+  //expose_video_io();
 }


### PR DESCRIPTION
As the title says. This is a temporary workaround to avoid conflict between different version of FFmpeg libraries. It looks we will really need to make the video I/O optional (#242).