### PR TITLE
ENH: option to randomly seed Mersenne-Twister RNG in normal distribution.

### DIFF
--- a/cpp/src/DO/Sara/ImageProcessing/ColorJitter.hpp
+++ b/cpp/src/DO/Sara/ImageProcessing/ColorJitter.hpp
@@ -21,10 +21,13 @@
 
 namespace DO { namespace Sara {
 
-  struct NormalDistribution
+  class NormalDistribution
   {
-    NormalDistribution()
+  public:
+    NormalDistribution(bool seed_randomly = true)
     {
+      if (seed_randomly)
+        _gen = randomly_seeded_mersenne_twister();
     }
 
     float operator()() const
@@ -51,6 +54,19 @@ namespace DO { namespace Sara {
       image.cwise_transform_inplace(randn_pixel);
     }
 
+  private:
+    auto randomly_seeded_mersenne_twister() -> std::mt19937
+    {
+      constexpr auto N = std::mt19937::state_size;
+      unsigned random_data[N];
+      std::random_device source;
+      std::generate(std::begin(random_data), std::end(random_data),
+                    std::ref(source));
+      std::seed_seq seeds(std::begin(random_data), std::end(random_data));
+      return std::mt19937{seeds};
+    }
+
+  private:
     mutable std::mt19937 _gen;
     mutable std::normal_distribution<float> _dist;
   };

--- a/cpp/test/ImageProcessing/test_imageprocessing_color_jittering.cpp
+++ b/cpp/test/ImageProcessing/test_imageprocessing_color_jittering.cpp
@@ -20,23 +20,44 @@ using namespace std;
 using namespace DO::Sara;
 
 
+TEST(TestNormalDistribution, test_random_seed)
+{
+  auto dist = NormalDistribution{false};
+  auto dist2 = NormalDistribution{true};
+
+  auto samples1 = vector<float>{};
+  auto samples2 = vector<float>{};
+  auto sample1_i = back_inserter(samples1);
+  auto sample2_i = back_inserter(samples2);
+
+  for (int i = 0; i < 10; ++i)
+  {
+    *sample1_i++ = dist();
+    *sample2_i++ = dist2();
+  }
+
+  EXPECT_EQ(samples1.size(), 10u);
+  EXPECT_EQ(samples2.size(), 10u);
+  EXPECT_NE(samples1, samples2);
+}
+
 TEST(TestNormalDistribution, test_sampling)
 {
-  auto dist = NormalDistribution{};
+  auto dist = NormalDistribution{false};
 
   auto samples = vector<float>{};
   auto sample_i = back_inserter(samples);
   for (int i = 0; i < 10; ++i)
     *sample_i++ = dist();
 
-  EXPECT_EQ(samples.size(), 10);
+  EXPECT_EQ(samples.size(), 10u);
   for (const auto& s : samples)
     EXPECT_NE(s, 0.f);
 }
 
 TEST(TestNormalDistribution, test_randn_vector)
 {
-  const auto randn = NormalDistribution{};
+  const auto randn = NormalDistribution{false};
   auto v = Vector3f{};
   randn(v);
   EXPECT_TRUE(v != Vector3f::Zero());
@@ -48,7 +69,7 @@ TEST(TestNormalDistribution, test_randn_vector)
 
 TEST(TestNormalDistribution, test_randn_image)
 {
-  const auto randn = NormalDistribution{};
+  const auto randn = NormalDistribution{false};
   auto image = Image<Rgb32f>{5, 5};
   image.array().fill(Rgb32f::Zero());
 
@@ -62,7 +83,7 @@ TEST(TestNormalDistribution, test_add_randn_noise)
   auto image = Image<Rgb32f>{5, 5};
   image.array().fill(Rgb32f::Zero());
 
-  const auto randn = NormalDistribution{};
+  const auto randn = NormalDistribution{false};
   add_randn_noise(image, 0.5, randn);
   for (const auto& pixel : image)
     EXPECT_TRUE(pixel != Vector3f::Zero());

--- a/cpp/test/ImageProcessing/test_imageprocessing_data_augmentation.cpp
+++ b/cpp/test/ImageProcessing/test_imageprocessing_data_augmentation.cpp
@@ -157,7 +157,7 @@ TEST(TestDataTransformEnumeration, test_compose_with_random_pca)
   const auto num_samples = 10;
 
   const auto parent_t = ImageDataTransform{};
-  const auto dist = NormalDistribution{};
+  const auto dist = NormalDistribution{false};
   const auto ts =
       compose_with_random_fancy_pca(parent_t, num_samples, std_dev, dist);
   EXPECT_EQ(10u, ts.size());
@@ -174,7 +174,7 @@ TEST(TestDataTransformEnumeration,
   const auto shift_delta = Vector2i::Ones();
   const auto flip = false;
 
-  const auto randn = NormalDistribution{};
+  const auto randn = NormalDistribution{false};
 
   const auto ts = enumerate_image_data_transforms(
       in_sizes, out_sizes,
@@ -200,7 +200,7 @@ TEST(TestDataTransformEnumeration,
   const auto shift_delta = Vector2i::Ones();
   const auto flip = false;
 
-  const auto randn = NormalDistribution{};
+  const auto randn = NormalDistribution{false};
 
   const auto ts = enumerate_image_data_transforms(
       in_sizes, out_sizes,
@@ -231,7 +231,7 @@ TEST(TestDataTransformEnumeration,
   const auto shift_delta = Vector2i::Ones();
   const auto flip = false;
   const auto fancy_pca = false;
-  const auto randn = NormalDistribution{};
+  const auto randn = NormalDistribution{false};
 
   const auto ts = enumerate_image_data_transforms(
       in_sizes, out_sizes,
@@ -262,7 +262,7 @@ TEST(TestDataTransformEnumeration,
   const auto shift_delta = Vector2i::Ones();
   const auto flip = true;
   const auto fancy_pca = false;
-  const auto randn = NormalDistribution{};
+  const auto randn = NormalDistribution{false};
 
   const auto ts = enumerate_image_data_transforms(
       in_sizes, out_sizes,
@@ -290,7 +290,7 @@ TEST(TestDataTransformEnumeration,
   const auto shift_delta = Vector2i::Ones();
   const auto flip = false;
   const auto fancy_pca = true;
-  const auto randn = NormalDistribution{};
+  const auto randn = NormalDistribution{false};
 
   const auto ts = enumerate_image_data_transforms(
       in_sizes, out_sizes,
@@ -322,7 +322,7 @@ TEST(TestDataTransformEnumeration, test_all)
   const auto shift_delta = Vector2i::Ones();
   const auto flip = true;
   const auto fancy_pca = true;
-  const auto randn = NormalDistribution{};
+  const auto randn = NormalDistribution{false};
 
   const auto ts = enumerate_image_data_transforms(
       in_sizes, out_sizes,
@@ -357,7 +357,7 @@ TEST(TestDataAugmentation, test_augment_dataset)
   const auto flip = false;
   const auto fancy_pca = false;
 
-  const auto randn = NormalDistribution{};
+  const auto randn = NormalDistribution{false};
 
   const auto augmented_data = augment_data(
       data_indices,


### PR DESCRIPTION
This fixes #296.