### PR TITLE
ENH: add row major tensor views for image views.

### DIFF
--- a/cpp/src/DO/Sara/Core/Tensor.hpp
+++ b/cpp/src/DO/Sara/Core/Tensor.hpp
@@ -73,5 +73,29 @@ namespace DO { namespace Sara {
   }
   //! @}
 
+  //! @{
+  //! @brief Provide tensor views for image objects.
+  template <typename T, int N>
+  inline auto transposed_tensor_view(ImageView<T, N> in) ->TensorView<T, N, ColMajor>
+  {
+    return TensorView<T, N, ColMajor>{in.data(), in.sizes()};
+  }
+
+  template <typename ChannelType, typename ColorSpace, int Dim>
+  inline auto transposed_tensor_view(ImageView<Pixel<ChannelType, ColorSpace>, Dim> in)
+      -> TensorView<ChannelType, Dim + 1, ColMajor>
+  {
+    using tensor_type = TensorView<ChannelType, Dim + 1, ColMajor>;
+    using tensor_sizes_type = typename tensor_type::vector_type;
+    constexpr auto num_channels = ColorSpace::size;
+
+    auto out_sizes =
+        (tensor_sizes_type{} << num_channels, in.sizes()).finished();
+
+    return TensorView<ChannelType, Dim + 1, ColMajor>{
+        reinterpret_cast<ChannelType*>(in.data()), out_sizes};
+  }
+  //! @}
+
 } /* namespace Sara */
 } /* namespace DO */

--- a/cpp/src/DO/Sara/Core/Tensor.hpp
+++ b/cpp/src/DO/Sara/Core/Tensor.hpp
@@ -30,13 +30,64 @@ namespace DO { namespace Sara {
   using Tensor = MultiArray<T, N, StorageOrder, Allocator>;
   //! @}
 
+
+  //! @{
+  //! @brief Provide tensor views for generic ND-array objects.
+  /*!
+   * If a tensor coefficient is not a scalar but a matricial object, then the
+   * function converts a ND-array of matrices into (N+2)D-array of scalars,
+   * i.e.:
+   *
+   * ```
+   * auto m = MultiArray<Matrix2f, 2>{2, 2};
+   * m.flat_array().fill(Matrix2f::Identity());
+   *
+   * auto t = tensor_view(m);
+   *
+   * std::cout << "t(c,r,i,j) == m(i,j)(c,r) is "
+   *           << std::boolapha << t(c,r,i,j) == m(i,j)(c,r) << std::endl;
+   * // true.
+   *
+   * ```
+   */
+  template <typename T, int M, int N, int Dim, int StorageOrder>
+  inline auto tensor_view(MultiArrayView<Array<T, M, N>, Dim, StorageOrder> in)
+      -> MultiArrayView<T, Dim + 2, StorageOrder>
+  {
+    using tensor_type = TensorView<T, Dim + 2, StorageOrder>;
+    using tensor_sizes_type = typename tensor_type::vector_type;
+
+    const auto out_sizes =
+        StorageOrder == RowMajor
+            ? (tensor_sizes_type{} << in.sizes(), N, M).finished()
+            : (tensor_sizes_type{} << M, N, in.sizes()).finished();
+
+    return tensor_type{reinterpret_cast<T*>(in.data()), out_sizes};
+  }
+
+  template <typename T, int M, int N, int Dim, int StorageOrder>
+  inline auto tensor_view(MultiArrayView<Matrix<T, M, N>, Dim, StorageOrder> in)
+      -> MultiArrayView<T, Dim + 2, StorageOrder>
+  {
+    using tensor_type = TensorView<T, Dim + 2, StorageOrder>;
+    using tensor_sizes_type = typename tensor_type::vector_type;
+
+    const auto out_sizes =
+        StorageOrder == RowMajor
+            ? (tensor_sizes_type{} << in.sizes(), N, M).finished()
+            : (tensor_sizes_type{} << M, N, in.sizes()).finished();
+
+    return tensor_type{reinterpret_cast<T*>(in.data()), out_sizes};
+  }
+  //! @}
+
   //! @{
   //! @brief Provide tensor views for image objects.
   template <typename T, int N>
-  inline auto tensor_view(ImageView<T, N> in) ->TensorView<T, N, RowMajor>
+  inline auto tensor_view(ImageView<T, N> in) -> TensorView<T, N, RowMajor>
   {
     auto out_sizes = in.sizes();
-    std::reverse(out_sizes.data(), out_sizes.data() + out_sizes.size());
+    std::reverse(out_sizes.data(), out_sizes.data() + N);
     return TensorView<T, N, RowMajor>{in.data(), out_sizes};
   }
 
@@ -54,6 +105,32 @@ namespace DO { namespace Sara {
 
     return TensorView<ChannelType, Dim + 1, RowMajor>{
         reinterpret_cast<ChannelType*>(in.data()), out_sizes};
+  }
+
+  template <typename T, int M, int N, int Dim>
+  inline auto tensor_view(ImageView<Array<T, M, N>, Dim> in)
+      -> TensorView<T, Dim + 2, RowMajor>
+  {
+    using tensor_type = TensorView<T, Dim + 2, RowMajor>;
+    using tensor_sizes_type = typename tensor_type::vector_type;
+
+    auto out_sizes = (tensor_sizes_type{} << in.sizes(), N, M).finished();
+    std::reverse(out_sizes.data(), out_sizes.data() + Dim);
+
+    return tensor_type{reinterpret_cast<T*>(in.data()), out_sizes};
+  }
+
+  template <typename T, int M, int N, int Dim>
+  inline auto tensor_view(ImageView<Matrix<T, M, N>, Dim> in)
+      -> TensorView<T, Dim + 2, RowMajor>
+  {
+    using tensor_type = TensorView<T, Dim + 2, RowMajor>;
+    using tensor_sizes_type = typename tensor_type::vector_type;
+
+    auto out_sizes = (tensor_sizes_type{} << in.sizes(), N, M).finished();
+    std::reverse(out_sizes.data(), out_sizes.data() + Dim);
+
+    return tensor_type{reinterpret_cast<T*>(in.data()), out_sizes};
   }
   //! @}
 

--- a/cpp/src/DO/Sara/Core/Tensor.hpp
+++ b/cpp/src/DO/Sara/Core/Tensor.hpp
@@ -76,23 +76,26 @@ namespace DO { namespace Sara {
   //! @{
   //! @brief Provide tensor views for image objects.
   template <typename T, int N>
-  inline auto transposed_tensor_view(ImageView<T, N> in) ->TensorView<T, N, ColMajor>
+  inline auto tensor_view(ImageView<T, N> in) ->TensorView<T, N, RowMajor>
   {
-    return TensorView<T, N, ColMajor>{in.data(), in.sizes()};
+    auto out_sizes = in.sizes();
+    std::reverse(out_sizes.data(), out_sizes.data() + out_sizes.size());
+    return TensorView<T, N, RowMajor>{in.data(), out_sizes};
   }
 
   template <typename ChannelType, typename ColorSpace, int Dim>
-  inline auto transposed_tensor_view(ImageView<Pixel<ChannelType, ColorSpace>, Dim> in)
-      -> TensorView<ChannelType, Dim + 1, ColMajor>
+  inline auto tensor_view(ImageView<Pixel<ChannelType, ColorSpace>, Dim> in)
+      -> TensorView<ChannelType, Dim + 1, RowMajor>
   {
     using tensor_type = TensorView<ChannelType, Dim + 1, ColMajor>;
     using tensor_sizes_type = typename tensor_type::vector_type;
     constexpr auto num_channels = ColorSpace::size;
 
     auto out_sizes =
-        (tensor_sizes_type{} << num_channels, in.sizes()).finished();
+        (tensor_sizes_type{} << in.sizes(), num_channels).finished();
+    std::reverse(out_sizes.data(), out_sizes.data() + Dim);
 
-    return TensorView<ChannelType, Dim + 1, ColMajor>{
+    return TensorView<ChannelType, Dim + 1, RowMajor>{
         reinterpret_cast<ChannelType*>(in.data()), out_sizes};
   }
   //! @}

--- a/cpp/test/Core/test_core_tensor.cpp
+++ b/cpp/test/Core/test_core_tensor.cpp
@@ -112,6 +112,88 @@ TEST(TestTensorView, test_color_case)
         ASSERT_EQ((c + 1) * (x + y * t.size(1)), t(y, x, c));
 }
 
+TEST(TestTensorView, test_matrix_case)
+{
+  constexpr auto W = 2, H = 3, M = 2, N = 3;
+  auto img = Image<Matrix<float, M, N>>{W, H};  // Indexed by (y, x, j, i).
+
+  auto img_elem = Matrix<float, M, N>{};
+  std::iota(img_elem.data(), img_elem.data() + M * N, 0);
+  img.array().fill(img_elem);
+
+  auto m = img.matrix();
+  m(0,0) *= 0; m(0,1) *= 1;
+  m(1,0) *= 2; m(1,1) *= 3;
+  m(2,0) *= 4; m(2,1) *= 5;
+  /*
+   * [[0, 0, 0],  [[0, 2, 4],
+   *  [0, 0, 0]]   [1, 3, 5]]
+   *
+   * [[0, 4, 8],  [[0, 6,12],
+   *  [2, 6,10]]   [3, 9,15]]
+   *
+   * [[0, 8,16],  [[0,10,20],
+   *  [4,12,20]]   [5,15,25]]
+   *
+   */
+
+  const auto t = tensor_view(img);  // Indexed by (y, x, j, i).
+
+  EXPECT_EQ(M, t.size(3));
+  EXPECT_EQ(N, t.size(2));
+  EXPECT_EQ(W, t.size(1));
+  EXPECT_EQ(H, t.size(0));
+  EXPECT_EQ(img.width(), t.size(1));
+  EXPECT_EQ(img.height(), t.size(0));
+
+  for (int y = 0; y < t.size(0); ++y)
+    for (int x = 0; x < t.size(1); ++x)
+      for (int j = 0; j < t.size(2); ++j)
+        for (int i = 0; i < t.size(3); ++i)
+          ASSERT_EQ(img_elem(i, j) * (y * W + x), t(Vector4i{y, x, j, i}));
+}
+
+TEST(TestTensorView, test_array_case)
+{
+  constexpr auto W = 2, H = 3, M = 2, N = 3;
+  auto img = Image<Array<float, M, N>>{W, H};  // Indexed by (y, x, j, i).
+
+  auto img_elem = Array<float, M, N>{};
+  std::iota(img_elem.data(), img_elem.data() + M * N, 0);
+  img.array().fill(img_elem);
+
+  auto m = img.matrix();
+  m(0,0) *= 0; m(0,1) *= 1;
+  m(1,0) *= 2; m(1,1) *= 3;
+  m(2,0) *= 4; m(2,1) *= 5;
+  /*
+   * [[0, 0, 0],  [[0, 2, 4],
+   *  [0, 0, 0]]   [1, 3, 5]]
+   *
+   * [[0, 4, 8],  [[0, 6,12],
+   *  [2, 6,10]]   [3, 9,15]]
+   *
+   * [[0, 8,16],  [[0,10,20],
+   *  [4,12,20]]   [5,15,25]]
+   *
+   */
+
+  const auto t = tensor_view(img);  // Indexed by (y, x, j, i).
+
+  EXPECT_EQ(M, t.size(3));
+  EXPECT_EQ(N, t.size(2));
+  EXPECT_EQ(W, t.size(1));
+  EXPECT_EQ(H, t.size(0));
+  EXPECT_EQ(img.width(), t.size(1));
+  EXPECT_EQ(img.height(), t.size(0));
+
+  for (int y = 0; y < t.size(0); ++y)
+    for (int x = 0; x < t.size(1); ++x)
+      for (int j = 0; j < t.size(2); ++j)
+        for (int i = 0; i < t.size(3); ++i)
+          EXPECT_EQ(img_elem(i, j) * (y * W + x), t(Vector4i{y, x, j, i}));
+}
+
 int main(int argc, char** argv)
 {
   testing::InitGoogleTest(&argc, argv);

--- a/cpp/test/Core/test_core_tensor.cpp
+++ b/cpp/test/Core/test_core_tensor.cpp
@@ -85,8 +85,8 @@ TEST(TestTensorViews, test_grayscale_case)
     2, 3,
     4, 5;
 
-  const auto tensor = transposed_tensor_view(image);
-  EXPECT_MATRIX_EQ(image.matrix(), tensor.matrix().transpose());
+  const auto tensor = tensor_view(image);
+  EXPECT_MATRIX_EQ(image.matrix(), tensor.matrix());
 }
 
 TEST(TestTensorView, test_color_case)
@@ -99,17 +99,17 @@ TEST(TestTensorView, test_color_case)
   m(1,0) *= 2; m(1,1) *= 3;
   m(2,0) *= 4; m(2,1) *= 5;
 
-  const auto t = transposed_tensor_view(image);
+  const auto t = tensor_view(image);
 
-  // Indexed by (c, x, y).
-  EXPECT_EQ(Rgb32f::num_channels(), t.size(0));
+  // Indexed by (y, x, c).
+  EXPECT_EQ(Rgb32f::num_channels(), t.size(2));
   EXPECT_EQ(image.width(), t.size(1));
-  EXPECT_EQ(image.height(), t.size(2));
+  EXPECT_EQ(image.height(), t.size(0));
 
   for (int y = 0; y < t.size(0); ++y)
     for (int x = 0; x < t.size(1); ++x)
       for (int c = 0; c < t.size(2); ++c)
-        ASSERT_EQ((c + 1) * (x + y * t.size(1)), t(c, x, y));
+        ASSERT_EQ((c + 1) * (x + y * t.size(1)), t(y, x, c));
 }
 
 int main(int argc, char** argv)

--- a/cpp/test/Core/test_core_tensor.cpp
+++ b/cpp/test/Core/test_core_tensor.cpp
@@ -77,6 +77,40 @@ TEST(TestConversionImageToTensor, test_color_case)
   EXPECT_MATRIX_EQ(true_b.matrix(), b);
 }
 
+TEST(TestTensorViews, test_grayscale_case)
+{
+  auto image = Image<float>{2, 3};
+  image.matrix() <<
+    0, 1,
+    2, 3,
+    4, 5;
+
+  const auto tensor = transposed_tensor_view(image);
+  EXPECT_MATRIX_EQ(image.matrix(), tensor.matrix().transpose());
+}
+
+TEST(TestTensorView, test_color_case)
+{
+  auto image = Image<Rgb32f>{2, 3};
+  auto m = image.matrix();
+  m.fill(Rgb32f{1.,2.,3.});
+
+  m(0,0) *= 0; m(0,1) *= 1;
+  m(1,0) *= 2; m(1,1) *= 3;
+  m(2,0) *= 4; m(2,1) *= 5;
+
+  const auto t = transposed_tensor_view(image);
+
+  // Indexed by (c, x, y).
+  EXPECT_EQ(Rgb32f::num_channels(), t.size(0));
+  EXPECT_EQ(image.width(), t.size(1));
+  EXPECT_EQ(image.height(), t.size(2));
+
+  for (int y = 0; y < t.size(0); ++y)
+    for (int x = 0; x < t.size(1); ++x)
+      for (int c = 0; c < t.size(2); ++c)
+        ASSERT_EQ((c + 1) * (x + y * t.size(1)), t(c, x, y));
+}
 
 int main(int argc, char** argv)
 {


### PR DESCRIPTION
Image data is stored in column major order. We provide row-major tensor views for them.

This fixes #295.